### PR TITLE
feat: 댓글/대댓글 UI 구분 및 수정/삭제 기능 구현

### DIFF
--- a/src/api/commentApi.js
+++ b/src/api/commentApi.js
@@ -20,5 +20,15 @@ export default function commentApi(){
         return await request("post", "/api/admin/comments", commentData, config);
     }
 
-    return { commentCount, commentList, createComment };
+    const updateComment = async (commentId, commentData) => {
+        const config = getAuthHeaders();
+        return await request("put", `/api/admin/comments/${commentId}`, commentData, config);
+    }
+
+    const deleteComment = async (commentId) => {
+        const config = getAuthHeaders();
+        return await request("delete", `/api/admin/comments/${commentId}`, null, config);
+    }
+
+    return { commentCount, commentList, createComment, updateComment, deleteComment };
 }

--- a/src/components/comment/CommentItem.jsx
+++ b/src/components/comment/CommentItem.jsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+
+export default function CommentItem({
+                                        comment,
+                                        isReply = false,
+                                        onReply,
+                                        onEdit,
+                                        onDelete,
+                                        replyingTo,
+                                        replyContent,
+                                        setReplyContent,
+                                        onSubmitReply,
+                                        onCancelReply
+                                    }) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editContent, setEditContent] = useState(comment.content);
+
+    const formatTime = (timestamp) => {
+        if (!timestamp) return '';
+        const date = new Date(timestamp);
+        const now = new Date();
+        const diff = Math.floor((now - date) / 1000);
+
+        if (diff < 60) return '방금 전';
+        if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+        if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+        return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+    };
+
+    const handleEdit = () => {
+        setIsEditing(true);
+    };
+
+    const handleSaveEdit = () => {
+        if (!editContent.trim()) {
+            alert("댓글 내용을 입력해주세요.");
+            return;
+        }
+        onEdit(comment.id, editContent);
+        setIsEditing(false);
+    };
+
+    const handleCancelEdit = () => {
+        setEditContent(comment.content);
+        setIsEditing(false);
+    };
+
+    return (
+        <div className={`${isReply ? 'ml-12 border-l-2 border-gray-200 pl-4' : ''}`}>
+            <div className="flex gap-3 px-2 group hover:bg-gray-50 rounded-lg transition-colors py-2">
+                {/* 프로필 이미지 영역 */}
+                <div className="flex-shrink-0">
+                    <div className={`${isReply ? 'w-8 h-8 text-xs' : 'w-10 h-10 text-sm'} rounded-full bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center text-white font-semibold`}>
+                        {(comment.nickname || "작성자")[0].toUpperCase()}
+                    </div>
+                </div>
+
+                {/* 메시지 영역 */}
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-baseline gap-2 mb-1">
+                        <span className="font-semibold text-gray-900 text-sm">
+                            {comment.nickname || "작성자"}
+                        </span>
+                        <span className="text-xs text-gray-400">
+                            {formatTime(comment.createdAt)}
+                        </span>
+                        {isReply && (
+                            <span className="text-xs text-blue-500 font-medium">답글</span>
+                        )}
+                    </div>
+
+                    {/* 수정 모드 */}
+                    {isEditing ? (
+                        <div className="space-y-2">
+                            <textarea
+                                value={editContent}
+                                onChange={(e) => setEditContent(e.target.value)}
+                                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                rows="3"
+                                autoFocus
+                            />
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={handleSaveEdit}
+                                    className="px-4 py-2 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                                >
+                                    저장
+                                </button>
+                                <button
+                                    onClick={handleCancelEdit}
+                                    className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+                                >
+                                    취소
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <>
+                            {/* 말풍선 스타일 */}
+                            <div className={`inline-block ${isReply ? 'bg-gray-50' : 'bg-white'} border border-gray-200 rounded-2xl rounded-tl-sm px-4 py-2.5 shadow-sm`}>
+                                <p className="text-gray-800 text-sm leading-relaxed break-words">
+                                    {comment.content}
+                                </p>
+                            </div>
+
+                            {/* 액션 버튼들 */}
+                            <div className="flex gap-3 mt-1.5 text-xs text-gray-500">
+                                {!isReply && (
+                                    <button
+                                        onClick={() => onReply(comment.id)}
+                                        className="hover:text-blue-600 font-medium"
+                                    >
+                                        답글
+                                    </button>
+                                )}
+                                <button
+                                    onClick={handleEdit}
+                                    className="hover:text-blue-600"
+                                >
+                                    수정
+                                </button>
+                                <button
+                                    onClick={() => onDelete(comment.id)}
+                                    className="hover:text-red-600"
+                                >
+                                    삭제
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+
+            {/* 대댓글 입력 폼 */}
+            {replyingTo === comment.id && (
+                <div className="mt-3 ml-12 border-l-2 border-blue-400 pl-4">
+                    <div className="bg-blue-50 rounded-lg p-3 space-y-2">
+                        <div className="flex items-center gap-2 mb-2">
+                            <svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                            </svg>
+                            <span className="text-xs text-blue-600 font-semibold">
+                                {comment.nickname}님에게 답글 작성
+                            </span>
+                        </div>
+                        <textarea
+                            value={replyContent}
+                            onChange={(e) => setReplyContent(e.target.value)}
+                            placeholder="답글을 입력하세요..."
+                            className="w-full px-3 py-2 text-sm border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none bg-white"
+                            rows="3"
+                            autoFocus
+                            onKeyPress={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                    e.preventDefault();
+                                    onSubmitReply(comment.id);
+                                }
+                            }}
+                        />
+                        <div className="flex justify-end gap-2">
+                            <button
+                                onClick={onCancelReply}
+                                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800"
+                            >
+                                취소
+                            </button>
+                            <button
+                                onClick={() => onSubmitReply(comment.id)}
+                                className="px-3 py-1.5 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                            >
+                                답글 등록
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/comment/CommentList.jsx
+++ b/src/components/comment/CommentList.jsx
@@ -34,15 +34,29 @@ export default function CommentList({ postId, refreshTrigger }) {
         return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
     };
 
-    const handleEdit = (commentId) => {
-        console.log("수정:", commentId);
-        // 수정 로직 구현
+    const handleEdit = async (commentId) => {
+        const comment = comments.find(c => c.id === commentId);
+        if (!comment) return;
+
+        const newContent = prompt("댓글 수정", comment.content);
+        if (!newContent || newContent === comment.content) return;
+
+        try {
+            await commentApi.updateComment(commentId, { content: newContent });
+            getCommentList(postId);
+        } catch (error) {
+            console.error("댓글 수정 에러", error);
+        }
     };
 
-    const handleDelete = (commentId) => {
-        if (window.confirm("댓글을 삭제하시겠습니까?")) {
-            console.log("삭제:", commentId);
-            // 삭제 로직 구현
+    const handleDelete = async (commentId) => {
+        if (!window.confirm("댓글을 삭제하시겠습니까?")) return;
+
+        try {
+            await commentApi.deleteComment(commentId);
+            getCommentList(postId);
+        } catch (error) {
+            console.error("댓글 삭제 에러", error);
         }
     };
 
@@ -55,8 +69,12 @@ export default function CommentList({ postId, refreshTrigger }) {
 
         try {
             // 대댓글 등록 API 호출
-            // await commentApi.createReply(parentId, replyContent);
-            console.log("대댓글 등록:", parentId, replyContent);
+            await commentApi.createComment({
+                postId: postId,
+                parentId: parentId,  // 부모 댓글 ID 전달
+                content: replyContent
+            });
+
             setReplyContent("");
             setReplyingTo(null);
             getCommentList(postId);

--- a/src/components/comment/CommentList.jsx
+++ b/src/components/comment/CommentList.jsx
@@ -5,6 +5,8 @@ export default function CommentList({ postId, refreshTrigger }) {
     const [comments, setComments] = useState([]);
     const [replyingTo, setReplyingTo] = useState(null);
     const [replyContent, setReplyContent] = useState("");
+    const [editingId, setEditingId] = useState(null);
+    const [editContent, setEditContent] = useState("");
     const commentApi = useComment();
 
     const getCommentList = async (postId) => {
@@ -34,19 +36,30 @@ export default function CommentList({ postId, refreshTrigger }) {
         return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
     };
 
-    const handleEdit = async (commentId) => {
-        const comment = comments.find(c => c.id === commentId);
-        if (!comment) return;
+    const handleEdit = (commentId, currentContent) => {
+        setEditingId(commentId);
+        setEditContent(currentContent);
+    };
 
-        const newContent = prompt("댓글 수정", comment.content);
-        if (!newContent || newContent === comment.content) return;
+    const submitEdit = async (commentId) => {
+        if (!editContent.trim()) {
+            alert("댓글 내용을 입력해주세요.");
+            return;
+        }
 
         try {
-            await commentApi.updateComment(commentId, { content: newContent });
+            await commentApi.updateComment(commentId, { content: editContent });
+            setEditingId(null);
+            setEditContent("");
             getCommentList(postId);
         } catch (error) {
             console.error("댓글 수정 에러", error);
         }
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditContent("");
     };
 
     const handleDelete = async (commentId) => {
@@ -62,19 +75,21 @@ export default function CommentList({ postId, refreshTrigger }) {
 
     const handleReply = (commentId) => {
         setReplyingTo(commentId);
+        setReplyContent("");
     };
 
     const submitReply = async (parentId) => {
-        if (!replyContent.trim()) return;
+        if (!replyContent.trim()) {
+            alert("답글 내용을 입력해주세요.");
+            return;
+        }
 
         try {
-            // 대댓글 등록 API 호출
             await commentApi.createComment({
                 postId: postId,
-                parentId: parentId,  // 부모 댓글 ID 전달
+                parentId: parentId,
                 content: replyContent
             });
-
             setReplyContent("");
             setReplyingTo(null);
             getCommentList(postId);
@@ -83,92 +98,104 @@ export default function CommentList({ postId, refreshTrigger }) {
         }
     };
 
-    const renderComment = (comment, isReply = false) => (
-        <div key={comment.id} className={`flex gap-3 px-2 group hover:bg-gray-50 rounded-lg transition-colors py-2 ${isReply ? 'ml-12' : ''}`}>
-            {/* 프로필 이미지 영역 */}
-            <div className="flex-shrink-0">
-                <div className={`${isReply ? 'w-8 h-8 text-xs' : 'w-10 h-10 text-sm'} rounded-full bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center text-white font-semibold`}>
-                    {(comment.nickname || "작성자")[0].toUpperCase()}
-                </div>
-            </div>
+    const renderComment = (comment) => {
+        // ✅ parentId가 있으면 대댓글
+        const isReply = comment.parentId !== null;
 
-            {/* 메시지 영역 */}
-            <div className="flex-1 min-w-0">
-                <div className="flex items-baseline gap-2 mb-1">
-                    <span className="font-semibold text-gray-900 text-sm">
-                        {comment.nickname || "작성자"}
-                    </span>
-                    <span className="text-xs text-gray-400">
-                        {formatTime(comment.createdAt || comment.timestamp)}
-                    </span>
-                </div>
-
-                {/* 말풍선 스타일 */}
-                <div className="inline-block bg-white border border-gray-200 rounded-2xl rounded-tl-sm px-4 py-2.5 shadow-sm">
-                    <p className="text-gray-800 text-sm leading-relaxed break-words">
-                        {comment.content}
-                    </p>
-                </div>
-
-                {/* 액션 버튼들 */}
-                <div className="flex gap-3 mt-1.5 text-xs text-gray-500">
-                    {!isReply && (
-                        <button
-                            onClick={() => handleReply(comment.id)}
-                            className="hover:text-blue-600"
-                        >
-                            답글
-                        </button>
-                    )}
-                    <button
-                        onClick={() => handleEdit(comment.id)}
-                        className="hover:text-blue-600"
-                    >
-                        수정
-                    </button>
-                    <button
-                        onClick={() => handleDelete(comment.id)}
-                        className="hover:text-red-600"
-                    >
-                        삭제
-                    </button>
-                </div>
-
-                {/* 대댓글 입력 폼 */}
-                {replyingTo === comment.id && (
-                    <div className="mt-3 flex gap-2">
-                        <input
-                            type="text"
-                            value={replyContent}
-                            onChange={(e) => setReplyContent(e.target.value)}
-                            placeholder="답글을 입력하세요..."
-                            className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            onKeyPress={(e) => {
-                                if (e.key === 'Enter') {
-                                    submitReply(comment.id);
-                                }
-                            }}
-                        />
-                        <button
-                            onClick={() => submitReply(comment.id)}
-                            className="px-4 py-2 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600"
-                        >
-                            등록
-                        </button>
-                        <button
-                            onClick={() => {
-                                setReplyingTo(null);
-                                setReplyContent("");
-                            }}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-                        >
-                            취소
-                        </button>
+        return (
+            <div
+                key={comment.id}
+                className={`flex gap-3 px-2 group hover:bg-gray-50 rounded-lg transition-colors py-2 
+                    ${isReply ? 'ml-12 border-l-2 border-blue-300 pl-4 bg-blue-50/30' : ''}`}
+            >
+                {/* 프로필 이미지 영역 */}
+                <div className="flex-shrink-0">
+                    <div className={`${isReply ? 'w-8 h-8 text-xs' : 'w-10 h-10 text-sm'} rounded-full bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center text-white font-semibold`}>
+                        {(comment.nickname || "작성자")[0].toUpperCase()}
                     </div>
-                )}
+                </div>
+
+                {/* 메시지 영역 */}
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-baseline gap-2 mb-1">
+                        <span className="font-semibold text-gray-900 text-sm">
+                            {comment.nickname || "작성자"}
+                        </span>
+                        <span className="text-xs text-gray-400">
+                            {formatTime(comment.createdAt || comment.timestamp)}
+                        </span>
+                        {/* ✅ 대댓글 뱃지 */}
+                        {isReply && (
+                            <span className="text-xs bg-blue-100 text-blue-600 px-2 py-0.5 rounded-full font-medium">
+                                답글
+                            </span>
+                        )}
+                    </div>
+
+                    {/* 수정 모드 */}
+                    {editingId === comment.id ? (
+                        <div className="space-y-2">
+                            <textarea
+                                value={editContent}
+                                onChange={(e) => setEditContent(e.target.value)}
+                                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                rows="3"
+                                autoFocus
+                            />
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={() => submitEdit(comment.id)}
+                                    className="px-4 py-2 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                                >
+                                    저장
+                                </button>
+                                <button
+                                    onClick={cancelEdit}
+                                    className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+                                >
+                                    취소
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <>
+                            {/* 말풍선 스타일 */}
+                            <div className={`inline-block ${isReply ? 'bg-white' : 'bg-white'} border border-gray-200 rounded-2xl rounded-tl-sm px-4 py-2.5 shadow-sm`}>
+                                <p className="text-gray-800 text-sm leading-relaxed break-words">
+                                    {comment.content}
+                                </p>
+                            </div>
+
+                            {/* 액션 버튼들 */}
+                            <div className="flex gap-3 mt-1.5 text-xs text-gray-500">
+                                {/* ✅ 대댓글에는 답글 버튼 안 보임 */}
+                                {!isReply && (
+                                    <button
+                                        onClick={() => handleReply(comment.id)}
+                                        className="hover:text-blue-600"
+                                    >
+                                        답글
+                                    </button>
+                                )}
+                                <button
+                                    onClick={() => handleEdit(comment.id, comment.content)}
+                                    className="hover:text-blue-600"
+                                >
+                                    수정
+                                </button>
+                                <button
+                                    onClick={() => handleDelete(comment.id)}
+                                    className="hover:text-red-600"
+                                >
+                                    삭제
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
             </div>
-        </div>
-    );
+        );
+    };
 
     return (
         <div className="space-y-4 py-4">
@@ -182,17 +209,62 @@ export default function CommentList({ postId, refreshTrigger }) {
                     <p className="text-gray-400 text-sm">등록된 댓글이 없습니다.</p>
                 </div>
             ) : (
-                comments.map((comment) => (
-                    <div key={comment.id}>
-                        {renderComment(comment)}
-                        {/* 대댓글 렌더링 */}
-                        {comment.replies && comment.replies.length > 0 && (
-                            <div className="space-y-2 mt-2">
-                                {comment.replies.map((reply) => renderComment(reply, true))}
-                            </div>
-                        )}
-                    </div>
-                ))
+                <div className="space-y-3">
+                    {comments.map((comment) => (
+                        <div key={comment.id}>
+                            {renderComment(comment)}
+
+                            {/* ✅ 대댓글 입력 폼 */}
+                            {replyingTo === comment.id && (
+                                <div className="ml-12 mt-3 border-l-2 border-blue-400 pl-4">
+                                    <div className="bg-blue-50 rounded-lg p-3 space-y-2">
+                                        <div className="flex items-center gap-2 mb-2">
+                                            <svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                                            </svg>
+                                            <span className="text-xs text-blue-600 font-semibold">
+                                                {comment.nickname}님에게 답글 작성
+                                            </span>
+                                        </div>
+                                        <textarea
+                                            value={replyContent}
+                                            onChange={(e) => setReplyContent(e.target.value)}
+                                            placeholder="답글을 입력하세요..."
+                                            className="w-full px-3 py-2 text-sm border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none bg-white"
+                                            rows="3"
+                                            autoFocus
+                                            onKeyPress={(e) => {
+                                                if (e.key === 'Enter' && !e.shiftKey) {
+                                                    e.preventDefault();
+                                                    submitReply(comment.id);
+                                                }
+                                            }}
+                                        />
+                                        <div className="flex justify-end gap-2">
+                                            <button
+                                                onClick={() => {
+                                                    setReplyingTo(null);
+                                                    setReplyContent("");
+                                                }}
+                                                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800"
+                                            >
+                                                취소
+                                            </button>
+                                            <button
+                                                onClick={() => submitReply(comment.id)}
+                                                className="px-3 py-1.5 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                                            >
+                                                답글 등록
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* ✅ 대댓글 렌더링 제거 (replies 배열 사용 안 함) */}
+                        </div>
+                    ))}
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## 개요
댓글 CRUD 기능을 완성하고, parentId 기반으로 대댓글을 시각적으로 구분하여 사용자 경험을 개선했습니다.

## 주요 변경사항

### 1. 댓글 API 연동
- `updateComment`: PATCH 요청으로 댓글 수정 API 추가
- `deleteComment`: DELETE 요청으로 댓글 삭제 API 추가

### 2. 댓글/대댓글 UI 구분
- `parentId` 기반으로 대댓글 자동 판별
- 대댓글 시각적 구분: 오른쪽 들여쓰기(ml-12), 파란 세로선, 배경색
- 대댓글에 '답글' 뱃지 표시
- 대댓글에는 답글 버튼 숨김 처리

### 3. 댓글 수정/삭제 기능
- 인라인 수정: textarea로 전환하여 현장 수정
- 삭제: confirm 후 API 호출 및 목록 새로고침
- 각 작업 후 댓글 목록 자동 갱신

### 4. 대댓글 작성 UI 개선
- 파란색 테마로 답글 작성 영역 강조
- 작성 대상 표시 ("~님에게 답글 작성")
- Enter 키로 답글 등록 (Shift+Enter는 줄바꿈)
- autoFocus로 사용자 편의성 향상